### PR TITLE
lib: add RawDecoder::new_boxed

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ mp1-mp2 = []
 nightly-docs = [] # internal
 simd = []
 std = []
+new-boxed = ["std"]
 
 [package.metadata.docs.rs]
 features = ["nightly-docs", "std"]

--- a/README.md
+++ b/README.md
@@ -55,3 +55,4 @@ https://github.com/rust-lang/cargo/issues/4328#issuecomment-652075026).**
 - `mp1-mp2`: Includes MP1 and MP2 decoding code.
 - `simd` *(default)*: Enables handwritten SIMD optimizations on eligible targets.
 - `std`: Adds things that require `std`,
+- `new-boxed`: Adds RawDecoder::new_boxed. Requires nightly and `std`.


### PR DESCRIPTION
RawDecoder struct is quite large (6.6 KB). With the current API,
I could not find a way to allocate directly on the heap without
a copy from the stack.

Add a new function new_boxed that uses nightly Box APIs to
allocate RawDecoder diretly on the heap.
